### PR TITLE
Update image tag to v1.0.4

### DIFF
--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -14,7 +14,7 @@ resources:
 # Image customization - override image tags
 images:
   - name: sleepup/sleepup
-    newTag: main
+    newTag: v1.0.4
 
 # Add prefix to all resource names to avoid conflicts
 namePrefix: sleepup-


### PR DESCRIPTION
### ⚠️ Merging this PR will trigger a deployment to the Kubernetes cluster using ArgoCD. ⚠️ 

## Summary
Automated PR to update the Kubernetes kustomization file with the new image tag from the latest release.

## Changes
- Updated `kubernetes/kustomization.yaml` image tag to ``
- This corresponds to the Docker image: `raelga/ff5-dreamroute:v1.0.4`

## Release Workflow
- Triggered by release workflow run: https://github.com/Femcoders-SleepUp/SleepUp/actions/runs/18225594001
- Release tag: `v1.0.4`